### PR TITLE
feat: `PATCH /items/{id}` エンドポイントを実装

### DIFF
--- a/internal/infrastructure/server/server.go
+++ b/internal/infrastructure/server/server.go
@@ -53,6 +53,7 @@ func (s *Server) Run(ctx context.Context) error {
 		itemsGroup.GET("", itemHandler.GetItems)           // GET /items
 		itemsGroup.POST("", itemHandler.CreateItem)        // POST /items
 		itemsGroup.GET("/:id", itemHandler.GetItem)        // GET /items/{id}
+		itemsGroup.PATCH("/:id", itemHandler.UpdateItem)   // PATCH /items/{id}
 		itemsGroup.DELETE("/:id", itemHandler.DeleteItem)  // DELETE /items/{id}
 		itemsGroup.GET("/summary", itemHandler.GetSummary) // GET /items/summary (bonus)
 	}

--- a/internal/interfaces/controller/items/items_controller.go
+++ b/internal/interfaces/controller/items/items_controller.go
@@ -93,6 +93,56 @@ func (h *ItemHandler) CreateItem(c echo.Context) error {
 	return c.JSON(http.StatusCreated, item)
 }
 
+// UpdateItem はアイテムの部分更新を行うPATCHエンドポイント
+// PATCH /items/{id} に対応
+// name, brand, purchase_price のみ更新可能（部分更新対応）
+func (h *ItemHandler) UpdateItem(c echo.Context) error {
+	// URLパラメータからアイテムIDを取得
+	idStr := c.Param("id")
+	// 文字列のIDを64bit整数に変換
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		// IDが無効な場合は400エラーを返す
+		return c.JSON(http.StatusBadRequest, ErrorResponse{
+			Error: "invalid item ID",
+		})
+	}
+
+	// リクエストボディをUpdateItemInput構造体にバインド（JSONをGoの構造体に変換）
+	var input usecase.UpdateItemInput
+	if err := c.Bind(&input); err != nil {
+		// JSONの形式が不正な場合は400エラーを返す
+		return c.JSON(http.StatusBadRequest, ErrorResponse{
+			Error: "invalid request format",
+		})
+	}
+
+	// ユースケース層のUpdateItem関数を呼び出してアイテムを更新
+	item, err := h.itemUsecase.UpdateItem(c.Request().Context(), id, input)
+	if err != nil {
+		// アイテムが見つからない場合は404エラー
+		if domainErrors.IsNotFoundError(err) {
+			return c.JSON(http.StatusNotFound, ErrorResponse{
+				Error: "item not found",
+			})
+		}
+		// バリデーションエラーの場合は400エラー
+		if domainErrors.IsValidationError(err) {
+			return c.JSON(http.StatusBadRequest, ErrorResponse{
+				Error:   "validation failed",
+				Details: []string{err.Error()},
+			})
+		}
+		// その他のエラーは500エラー
+		return c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Error: "failed to update item",
+		})
+	}
+
+	// 更新成功時は200ステータスで更新されたアイテムをJSONで返す
+	return c.JSON(http.StatusOK, item)
+}
+
 func (h *ItemHandler) DeleteItem(c echo.Context) error {
 	idStr := c.Param("id")
 	id, err := strconv.ParseInt(idStr, 10, 64)

--- a/internal/usecase/repository.go
+++ b/internal/usecase/repository.go
@@ -17,6 +17,11 @@ type ItemRepository interface {
 	// Create creates a new item and returns it with the generated ID
 	Create(ctx context.Context, item *entity.Item) (*entity.Item, error)
 
+	// Update はアイテムの特定フィールドをIDで部分更新する
+	// *string, *int はポインタ型で、nilの場合は更新対象外を意味する
+	// 更新後のアイテムを返す
+	Update(ctx context.Context, id int64, name, brand *string, purchasePrice *int) (*entity.Item, error)
+
 	// Delete deletes an item by ID
 	Delete(ctx context.Context, id int64) error
 


### PR DESCRIPTION
## やったこと

`PATCH /items/{id}` エンドポイントの新規実装

- **更新対象**: `name`, `brand`, `purchase_price` のみ
- **不変フィールド**: `id`, `category`, `purchase_date`, `created_at`
- **部分更新**: 送信されたフィールドのみ更新

## 確認方法

### ユニットテスト
```bash
go test ./internal/usecase/ -v
```

### APIテスト
```bash
# 名前のみ更新
curl -X PATCH http://localhost:8080/items/1 \
  -H "Content-Type: application/json" \
  -d '{"name": "更新されたアイテム名"}'

# 複数フィールド更新
curl -X PATCH http://localhost:8080/items/1 \
  -H "Content-Type: application/json" \
  -d '{"brand": "新ブランド", "purchase_price": 2000000}'

# バリデーションエラー確認
curl -X PATCH http://localhost:8080/items/1 \
  -H "Content-Type: application/json" \
  -d '{"name": "", "purchase_price": -100}'
```

## セルフチェック

- [x] name, brand, purchase_price のみ更新可能
- [x] 不変フィールドは更新されない  
- [x] updated_at が自動更新される
- [x] 部分更新に対応
- [x] 適切なHTTPステータスコード（200/400/404）
- [x] バリデーションが動作
- [x] ユニットテストが全て通る
- [x] リンターエラーなし
- [x] プレースホルダでSQLインジェクション対策

## 補足
GO言語自体の理解度が低いので、処理ごとにコメントアウトしています。読みづらいと思いますが、ご容赦ください。